### PR TITLE
fix(navbar): use absolute path for pricing link

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -73,7 +73,7 @@ export function Navbar({ user, onSignOut, loading = false }: NavbarProps) {
               <Link href="/terms" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
                 Terms
               </Link>
-              <Link href="#pricing" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <Link href="/#pricing" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
                 Pricing
               </Link>
             </div>


### PR DESCRIPTION
### Summary
Fixes incorrect navigation when clicking the **Pricing** link from non-home pages by using an absolute hash path.

---

### Problem
The navbar used a relative hash anchor (`#pricing`).  
When clicked from routes like `/terms` or `/privacy`, the browser navigated to:

- /terms#pricing
- /privacy#pricing

instead of returning to the home page.

---

### Solution
Updated the link to use an absolute hash path (`/#pricing`) for consistent navigation.

---

### Changes Made
- Updated navbar `Pricing` link to use an absolute hash path
- Verified navigation behavior from non-home pages

---

### Fixes
- Fixes broken navigation from `/terms` and `/privacy`
- No breaking changes
- No impact on existing home page behavior

---

### Testing
- Navigated from `/terms` → clicked **Pricing** → correctly redirected to `/#pricing`
- Navigated from `/privacy` → clicked **Pricing** → correctly redirected to `/#pricing`

### Related Issue
Closes #22 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pricing link navigation to ensure proper routing behavior from any page location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->