### PR TITLE
fix: task form state and UUID error when selecting unassigned

### DIFF
--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -583,6 +583,7 @@ export default function ProjectPage() {
   };
 
   const openTaskDialog = (columnId: string) => {
+    resetTaskForm();
     setSelectedColumnId(columnId);
     setTaskDialogOpen(true);
   };
@@ -943,7 +944,7 @@ export default function ProjectPage() {
       </Tabs>
 
       {/* Edit Task Dialog */}
-      <Dialog key={editingTask?.id || 'edit-dialog'} open={editTaskDialogOpen} onOpenChange={setEditTaskDialogOpen}>
+      <Dialog key={editingTask?.id || 'edit-dialog'} open={editTaskDialogOpen} onOpenChange={(open) => { setEditTaskDialogOpen(open); if (!open) { setEditingTask(null); resetTaskForm(); } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Task</DialogTitle>
@@ -1018,7 +1019,7 @@ export default function ProjectPage() {
 
             <div className="space-y-2">
               <Label htmlFor="editAssignedTo">Assign To</Label>
-              <Select value={taskAssignedTo || ''} onValueChange={(value) => setTaskAssignedTo(value || undefined)}>
+              <Select value={taskAssignedTo || 'unassigned'} onValueChange={(value) => setTaskAssignedTo(value === 'unassigned' ? undefined : value)}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select team member (optional)" />
                 </SelectTrigger>
@@ -1038,7 +1039,7 @@ export default function ProjectPage() {
                 {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Update Task
               </Button>
-              <Button type="button" size="xs" variant="outline" onClick={() => setEditTaskDialogOpen(false)}>
+              <Button type="button" size="xs" variant="outline" onClick={() => { setEditTaskDialogOpen(false); setEditingTask(null); resetTaskForm(); }}>
                 Cancel
               </Button>
             </div>
@@ -1178,7 +1179,7 @@ export default function ProjectPage() {
       </Dialog>
 
       {/* Create Task Dialog */}
-      <Dialog open={taskDialogOpen} onOpenChange={setTaskDialogOpen}>
+      <Dialog open={taskDialogOpen} onOpenChange={(open) => { setTaskDialogOpen(open); if (!open) { resetTaskForm(); } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create New Task</DialogTitle>
@@ -1253,7 +1254,7 @@ export default function ProjectPage() {
 
             <div className="space-y-2">
               <Label htmlFor="assignedTo">Assign To</Label>
-              <Select value={taskAssignedTo || ''} onValueChange={(value) => setTaskAssignedTo(value || undefined)}>
+              <Select value={taskAssignedTo || 'unassigned'} onValueChange={(value) => setTaskAssignedTo(value === 'unassigned' ? undefined : value)}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select team member (optional)" />
                 </SelectTrigger>
@@ -1261,7 +1262,7 @@ export default function ProjectPage() {
                   <SelectItem value="unassigned">Unassigned</SelectItem>
                   {projectMembers.map((member) => (
                     <SelectItem key={member.user_id} value={member.user_id}>
-                      {member.profiles?.full_name || member.profiles?.email || 'Bilinmeyen Kullanıcı'}
+                      {member.profiles?.full_name || member.profiles?.email || 'Unknown User'}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -1273,7 +1274,7 @@ export default function ProjectPage() {
                 {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Create Task
               </Button>
-              <Button type="button" variant="outline" size="xs" onClick={() => setTaskDialogOpen(false)}>
+              <Button type="button" variant="outline" size="xs" onClick={() => { setTaskDialogOpen(false); resetTaskForm(); }}>
                 Cancel
               </Button>
             </div>


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the task form:

### 1. UUID error when selecting 'Unassigned'
When selecting 'Unassigned' from the assignee dropdown, the string value `'unassigned'` was being passed directly to the database as a UUID, causing an error.

**Fix:** Convert `'unassigned'` to `undefined`/`null` before saving.

### 2. Task form state persisting after cancel
When editing a task and clicking cancel, the form state would remain populated. Opening 'Create Task' afterwards would show the old values from the previous edit.

**Fix:** Reset form state when opening create dialog and when closing dialogs.

### Additional
- Reset `editingTask` state when closing edit dialog
- Fixed hardcoded Turkish text 'Bilinmeyen Kullanıcı' → 'Unknown User'

## Testing
- Tested locally with Supabase
- Create/edit/cancel flows working correctly
- Assignee dropdown handles 'Unassigned' without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task form state management when opening/closing dialogs to prevent stale data.
  * Improved "Assign To" selection to properly display and handle unassigned tasks.
  * Standardized display of unknown users across the member list for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->