### PR TITLE
fix: navbar pricing link uses absolute anchor path

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -73,7 +73,7 @@ export function Navbar({ user, onSignOut, loading = false }: NavbarProps) {
               <Link href="/terms" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
                 Terms
               </Link>
-              <Link href="#pricing" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <Link href="/#pricing" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
                 Pricing
               </Link>
             </div>


### PR DESCRIPTION
## Summary

Fixes the navbar Pricing link so it navigates to /#pricing (the home page with the pricing section anchor) instead of appending #pricing to the current route.

## Problem

When on pages like /terms or /privacy, clicking the Pricing link resulted in /terms#pricing or /privacy#pricing instead of /#pricing. This meant the page didn't navigate to the home page and the pricing section was never shown.

## Solution

Changed the Link href from #pricing to /#pricing:

// Before (relative hash — resolves against current route)
<Link href="#pricing">Pricing</Link>

// After (absolute path with hash — always goes to home page)
<Link href="/#pricing">Pricing</Link>

## Testing

1. Navigate to /
2. Click Terms → navigate to /terms
3. Click Pricing → should navigate to /#pricing (home page, pricing section visible)

## Related Issues

Fixes kanba-co/kanba#22 and kanba-co/kanba#21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation link for the pricing section to properly resolve when accessed from all routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->